### PR TITLE
omits src/ directory from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,1 @@
-source/
+src/


### PR DESCRIPTION
Previously, `source/` was being npm ignored which caused `src/` to be included
in the npm package.

This commit changes it to `src/`.