### PR TITLE
remove remaining dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3883,11 +3883,6 @@
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
       "dev": true
     },
-    "lodash.curry": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
-      "integrity": "sha1-JI42By7ekGUB11lmIAqG2riyMXA="
-    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,5 @@
     "tape": "4.9.1",
     "updtr": "2.0.0",
     "watch": "1.0.2"
-  },
-  "dependencies": {
-    "lodash.curry": "4.1.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,11 @@
-const get = require('lodash/fp/get');
-const capitalize = require('lodash/upperFirst');
+const get = (path, obj, def) => path
+  .split('.')
+  .every(step => ((obj = obj[step]) !== undefined)) ? obj : def;
+
+const capitalize = str => {
+  if (typeof str !== 'string' || !str) return '';
+  return str.charAt(0).toUpperCase() + str.slice(1);
+};
 
 const id = x => x;
 const selectIf = predicate => x => predicate(x) && x;


### PR DESCRIPTION
Lodash, even modularly imported, actually does seem to pull a whole lot of stuff during bundling. I tried making a UMD bundle with Rollup and it was [nearly 6800 lines](https://www.dropbox.com/s/tx6ofm7e5zzk4fs/autodux.umd.js?dl=0)! But those two dependencies were pretty straightforward to peel away; all the tests still pass. `lodash.curry` also seems to have been dropped at some point along the way, so I pulled that from the `package.json`. Resolves #27. 