### PR TITLE
Update tests

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,1 @@
+module.exports.SLICE_VALUE_ERROR = "Proper value of 'slice' is required!";

--- a/src/test.js
+++ b/src/test.js
@@ -207,7 +207,8 @@ describe('autodux({ actions: … }).reducer', async assert => {
 
     assert({
       given: "'autodux' is called with 'actions'",
-      should: 'return reducer that considers delivering action payloads',
+      should:
+        'return reducer that receives action payload as the second parameter',
       actual: [increment(), increment(), multiply({ by: 2 })].reduce(
         reducer,
         initial
@@ -248,26 +249,26 @@ describe('autodux({ slice: …, initial: … }).selectors', async assert => {
 
   {
     const rootState = {
-      sliceName: {
-        key1: 'value 1',
-        key2: 'value 2'
+      album: {
+        name: 'The Works',
+        year: 1984
       }
     };
 
     const {
-      selectors: { getKey1, getKey2 },
+      selectors: { getName, getYear },
       initial
     } = autodux({
-      slice: 'sliceName',
-      initial: rootState.sliceName
+      slice: 'album',
+      initial: rootState.album
     });
 
     assert({
       given: "'autodux' is called with 'slice' and 'initial'",
       should: 'expose a selector for each key in the initial state',
       actual: {
-        key1: getKey1(rootState),
-        key2: getKey2(rootState)
+        name: getName(rootState),
+        year: getYear(rootState)
       },
       expected: initial
     });


### PR DESCRIPTION
Existing tests had some repetition and wrong grouping. Thus, some changes were introduced to ease reading tests and using `autodux`:

* Refactor the original test "dux" into `createCounterDux` and use it where possible.
* Group tests by the module under test (`slice`, `actions`, `reducer`, etc.)
* Remove duplicated tests.
* Add tests for cases when `autodux` is called without an argument. These tests may help to consider edge cases during further evolution of `autodux`.
* Add test for `initial`.