### PR TITLE
Use dist files instead of source files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "autodux",
   "version": "5.0.0",
   "description": "Automate the Redux boilerplate.",
-  "main": "index.js",
-  "module": "src/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index-esm.js",
   "scripts": {
     "lint": "npm run -s lint-js && npm run -s lint-md && echo 'Lint finished.'",
     "lint-js": "eslint .",


### PR DESCRIPTION
Currently on last version, the files served by the library are the source files, not the dist files, so it makes applications that use autodux crash with browsers that dont support ES6 syntax.

Related issue : https://github.com/ericelliott/autodux/issues/93