### PR TITLE
Fixed missing ./ in local require path

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 // eslint-disable-next-line no-global-assign
 require = require('esm')(module);
 
-module.exports = require('src/index.js');
+module.exports = require('./src/index.js');


### PR DESCRIPTION
This should fix the `Error: Cannot find module 'src/index.js'` errors, which was probably introduced via the changes in this commit: https://github.com/ericelliott/autodux/commit/08851126f700cfa49c71a64dd6c3261d4e92186a